### PR TITLE
Fix order of ops in outer loop

### DIFF
--- a/src/calculate.c
+++ b/src/calculate.c
@@ -247,14 +247,19 @@ doiteration(
             profile(CALC_NUCLEATION);
         }
         {
+            // update gr on CPU before ops on gr
+            gr_dataexchange_from(lsp, NULL);
+
             activateNewGrains();
             profile(GRAIN_ACTIVATION);
         }
 
-        // start communicating gr
         {
             //No need to copy back from GPU since gr was just set on CPU
-            //        ExchangeFacesForVar(grain_var);
+            ExchangeFacesForVar(grain_var, lsp->gr);
+            FinishExchangeForVar(grain_var, lsp->gr);
+            gr_dataexchange_to(lsp, NULL);
+            profile(OFFLOADING_CPU_GPU);
         }
 
         {
@@ -294,16 +299,6 @@ doiteration(
             profile(CALC_GROW_OCTAHEDRA);
         }
 
-        // finish communications for gr
-        {
-
-            gr_dataexchange_from(lsp, NULL);
-            profile(OFFLOADING_GPU_CPU);
-            ExchangeFacesForVar(grain_var, lsp->gr);
-            FinishExchangeForVar(grain_var, lsp->gr);
-            gr_dataexchange_to(lsp, NULL);
-            profile(OFFLOADING_CPU_GPU);
-        }
         // finish communications for dc
         {
             FinishExchangeForVar(dc_var, lsp->dc);


### PR DESCRIPTION
@lang-yuan It looks like we still had an issue with the order of ops in calculate.c. Can you double check my proposed changes?